### PR TITLE
Support custom configuration for storageClient

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -850,7 +850,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     }
 
     async getRequestQueue() {
-        this.requestQueue ??= await RequestQueue.open();
+        this.requestQueue ??= await RequestQueue.open(null, { config: this.config });
 
         return this.requestQueue!;
     }


### PR DESCRIPTION
Previously the crawler would load the storageClient from the global config, whereas this change allows the storageClient supplied via /custom/ (not global) configuration to be respected.